### PR TITLE
Adding shuffle to the random-seed library

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Supply your own random seed to the clojure.core random functions.
 
 ## Leiningen
 
-    [random-seed "1.0.0"]
+    [random-seed "1.0.1"]
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Supply your own random seed to the clojure.core random functions.
 
     (ns example.core
       (:require [random-seed.core :refer :all])
-      (:refer-clojure :exclude [rand rand-int rand-nth]))
+      (:refer-clojure :exclude [rand rand-int rand-nth shuffle]))
 
     (set-random-seed! 888)
 
@@ -19,6 +19,8 @@ Supply your own random seed to the clojure.core random functions.
     (rand-int 30)
 
     (rand-nth [:a :b :c])
+
+    (shuffle [:a :b :c])
 
 ## License
 

--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
-(defproject random-seed "1.0.0"
-  :description "Copies of rand, rand-int, and rand-nth, except you can specify the seed."
+(defproject random-seed "1.0.1"
+  :description "Copies of rand, rand-int, rand-nth and shuffle, except you can specify the seed."
   :url "https://www.github.com/trystan/random-seed"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.5.1"]])
+  :dependencies [[org.clojure/clojure "1.8.0"]])

--- a/src/random_seed/core.clj
+++ b/src/random_seed/core.clj
@@ -1,5 +1,5 @@
 (ns random-seed.core
-  (:refer-clojure :exclude [rand rand-int rand-nth]))
+  (:refer-clojure :exclude [rand rand-int rand-nth shuffle]))
 
 
 (defonce rng (new java.util.Random))
@@ -30,3 +30,11 @@
   specified in set-random-seed!."
   [coll]
   (nth coll (rand-int (count coll))))
+
+(defn shuffle
+  "Return a random permutation of coll. Works like clojure.core/shuffle
+  except it uses the seed specified in set-random-seed!."
+  [^java.util.Collection coll]
+  (let [al (java.util.ArrayList. coll)]
+    (java.util.Collections/shuffle al rng)
+    (clojure.lang.RT/vector (.toArray al))))


### PR DESCRIPTION
Hi Trystan,

The `shuffle` function from clojure.core also relies on `java.util.Random,` so I thought I'd copy it and incorporate it with the rng in your library so I have control over the seed when using it without the need for making my own additional library. I also took the liberty of updating the readme and project with the changes and updating to clojure 1.8.0.

I hope you can and want to merge the changes and upload them to clojars. I don't have experience with that and it seems cleaner to me anyway if these functions are in 1 library.

Best Regards & Happy Holidays, Sander.

sources used:
https://github.com/clojure/clojure/blob/master/src/clj/clojure/core.clj#L7149
http://stackoverflow.com/a/32452825/5211470
https://www.tutorialspoint.com/java/util/collections_shuffle_random.htm